### PR TITLE
Add MIT License for ECWOC'26 legal compliance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AtharvRG (Anchor) and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Description
This PR addresses the missing physical license file in the repository. While the `README.md` previously mentioned the MIT License, the absence of a dedicated LICENSE file left the project in a legal "All Rights Reserved" state.
By adding this file, we ensure that VYOM is officially open-source and ready for ECWOC'26 contributors.

Closes #57 

## License Selection: MIT
The MIT License was chosen because it is a permissive, short, and widely understood license that allows:
* Commercial Use
* Modification
* Distribution
* Private Use

## Changes
- [x] Created LICENSE file in the root directory.
- [x] Added standard MIT License text.
- [x] Set Copyright holder to AtharvRG (Anchor) and contributors.
- [x] Set Copyright year to 2026.

## Verification
I have verified that the license text matches the Open Source Initiative (OSI) standard and that the copyright line correctly identifies the project maintainer as requested in the issue.